### PR TITLE
Fix Supabase client initialization without credentials

### DIFF
--- a/app/lib/supabase.ts
+++ b/app/lib/supabase.ts
@@ -1,4 +1,4 @@
-import { createClient } from "@supabase/supabase-js";
+import { createClient, type SupabaseClient } from "@supabase/supabase-js";
 
 // Check if Supabase environment variables are available
 const hasSupabaseCredentials =
@@ -7,14 +7,33 @@ const hasSupabaseCredentials =
   !!process.env.NEXT_PUBLIC_SERVICE_KEY;
 
 // Initialize the Supabase client with public anon key (for client-side)
-const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL || "";
-const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || "";
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
 
-// Create a dummy client if credentials are missing
-export const supabase = createClient(supabaseUrl, supabaseAnonKey);
+let supabase: SupabaseClient;
+if (supabaseUrl && supabaseAnonKey) {
+  supabase = createClient(supabaseUrl, supabaseAnonKey);
+} else {
+  console.warn(
+    "Supabase credentials are missing. The Supabase client will run in mock mode."
+  );
+  // Provide an empty object typed as SupabaseClient to avoid runtime errors when
+  // imported in environments without credentials. Repository methods check for
+  // credentials before using the client, so this placeholder will never be
+  // invoked.
+  supabase = {} as SupabaseClient;
+}
+
+export { supabase };
 
 // Initialize a Supabase client with service role key (for server-side only)
-const supabaseServiceKey = process.env.NEXT_PUBLIC_SERVICE_KEY as string;
+const supabaseServiceKey = process.env.NEXT_PUBLIC_SERVICE_KEY;
 
-// Create a dummy admin client if credentials are missing
-export const supabaseAdmin = createClient(supabaseUrl, supabaseServiceKey);
+let supabaseAdmin: SupabaseClient;
+if (supabaseUrl && supabaseServiceKey) {
+  supabaseAdmin = createClient(supabaseUrl, supabaseServiceKey);
+} else {
+  supabaseAdmin = {} as SupabaseClient;
+}
+
+export { supabaseAdmin };


### PR DESCRIPTION
## Summary
- handle missing Supabase credentials gracefully

## Testing
- `pnpm test` *(fails: expected 0.5 to deeply equal 1.91343466063764)*

------
https://chatgpt.com/codex/tasks/task_e_684886994b7c8326a8cd81b80ed770ec