### PR TITLE
Analyze javascript session errors

### DIFF
--- a/app/[locale]/calculateur/bruxelles/questionnaire/page.tsx
+++ b/app/[locale]/calculateur/bruxelles/questionnaire/page.tsx
@@ -60,6 +60,13 @@ function DetailedQuestionnaireContent() {
   const [currentSection, setCurrentSection] = useState(0);
   const [isSubmitting, setIsSubmitting] = useState(false);
 
+  // Normalize a possibly non-array value (like a string) into a string[]
+  const toStringArray = useCallback((value: unknown): string[] => {
+    if (Array.isArray(value)) return value as string[];
+    if (value === undefined || value === null) return [];
+    return [String(value)];
+  }, []);
+
   // Get pre-filled data from global context
   const existingRent = globalForm.getActualRent();
   const existingSpace = globalForm.getLivingSpace();
@@ -431,10 +438,10 @@ function DetailedQuestionnaireContent() {
                   {t("problems.healthIssues.title")}
                 </Label>
                 <div className="space-y-2 mt-2">
-                  {(
+                  {toStringArray(
                     t("problems.healthIssues.items", {
                       returnObjects: true,
-                    }) as unknown as string[]
+                    }) as unknown
                   ).map((issue: string) => (
                     <div key={issue} className="flex items-center space-x-2">
                       <Checkbox
@@ -457,10 +464,10 @@ function DetailedQuestionnaireContent() {
                   {t("problems.majorDefects.title")}
                 </Label>
                 <div className="space-y-2 mt-2">
-                  {(
+                  {toStringArray(
                     t("problems.majorDefects.items", {
                       returnObjects: true,
-                    }) as unknown as string[]
+                    }) as unknown
                   ).map((defect: string) => (
                     <div key={defect} className="flex items-center space-x-2">
                       <Checkbox
@@ -503,10 +510,10 @@ function DetailedQuestionnaireContent() {
                 {t("positiveAspects.advantages")}
               </Label>
               <div className="space-y-2 mt-2">
-                {(
+                {toStringArray(
                   t("positiveAspects.items", {
                     returnObjects: true,
-                  }) as unknown as string[]
+                  }) as unknown
                 ).map((aspect: string) => (
                   <div key={aspect} className="flex items-center space-x-2">
                     <Checkbox


### PR DESCRIPTION
Safely normalize `next-intl` translation results before mapping to prevent `TypeError: .map is not a function`.

The `TypeError` occurs when `t(...)` returns a non-array value (e.g., a string) but is immediately followed by `.map()`. This can happen if locale files are misconfigured or `returnObjects: true` is not consistently used. This PR adds a `toStringArray` helper to ensure that the values passed to `.map()` are always arrays, even if the translation system returns a string or `undefined`, thus preventing UI crashes.

---
<a href="https://cursor.com/background-agent?bcId=bc-0ca9cba7-bd09-4458-a9e7-14789d1f5793"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-0ca9cba7-bd09-4458-a9e7-14789d1f5793"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

